### PR TITLE
Override cluster name from ENV/cli

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -9,13 +9,16 @@ import (
   "github.com/bartlettc22/kubeviz-agent/pkg/data"
 )
 
-var serverAddress, tokenAuth string
+var serverAddress, tokenAuth, clusterName string
 
-func Start(address string, token string) {
+func Start(address string, token string, cluster string) {
 
   serverAddress = address
   tokenAuth = token
-
+  clusterName = cluster
+  if clusterName != "" {
+    log.Info("Override cluster name = ", clusterName)
+  }
   data.Data.Metadata.AgentVersion = "0.2.0"
 
   tick := time.Tick(time.Duration(10000) * time.Millisecond)
@@ -30,9 +33,8 @@ func run() {
   start := time.Now()
   data.Data.Metadata.RunTime = start
 
-  kubernetes.Run(&data.Data.KubernetesResources)
+  kubernetes.Run(&data.Data.KubernetesResources, clusterName)
   aws.Run(&data.Data.AwsResources, &kubernetes.Resources.Metadata.ClusterName)
-
   data.Data.Metadata.RunDuration = time.Since(start)
 
   data, err := json.Marshal(data.Data)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,12 +10,15 @@ var serverAddress string
 var token string
 var awsAccessKeyId string
 var awsSecretAccessKey string
+var clusterName string
 
 func init() {
   startCmd.Flags().StringVarP(&serverAddress, "server-address", "s", "", "Kubeviz server address")
   viper.BindPFlag("server_address", startCmd.Flags().Lookup("server-address"))
   startCmd.Flags().StringVarP(&token, "token", "t", "", "server auth token")
   viper.BindPFlag("token", startCmd.Flags().Lookup("token"))
+  startCmd.Flags().StringVarP(&clusterName, "cluster-name", "c", "", "Set cluster name")
+  viper.BindPFlag("cluster_name", startCmd.Flags().Lookup("cluster-name"))
   rootCmd.AddCommand(startCmd)
 }
 
@@ -24,6 +27,6 @@ var startCmd = &cobra.Command{
   Short: "Start agent",
   Long:  `Starts the kubeviz agent`,
   Run: func(cmd *cobra.Command, args []string) {
-    agent.Start(viper.GetString("server_address"), viper.GetString("token"))
+    agent.Start(viper.GetString("server_address"), viper.GetString("token"), viper.GetString("cluster_name"))
   },
 }

--- a/helm_chart/kubeviz-agent/templates/deployment.yaml
+++ b/helm_chart/kubeviz-agent/templates/deployment.yaml
@@ -20,12 +20,22 @@ spec:
         component: {{.Values.Agent.ComponentName}}
         app: {{template "name" .}}
     spec:
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- else }}
       nodeSelector:
         role: master
+    {{- end }}
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: Exists
           effect: NoSchedule
+      {{- if .Values.Agent.RepoSecretName }}
+      imagePullSecrets:
+      # This must exist within the namespace in which you plan to deploy
+      - name: {{ .Values.Agent.RepoSecretName | quote }}
+      {{- end }}
       containers:
       - name: {{ template "fullname" . }}
         image: "{{.Values.Agent.Image}}:{{.Values.Agent.ImageTag}}"
@@ -39,3 +49,7 @@ spec:
           value: "{{ .Values.Agent.AwsAccessKey }}"
         - name: "AWS_SECRET_ACCESS_KEY"
           value: "{{ .Values.Agent.AwsSecretKey }}"
+        {{- if .Values.Agent.ClusterName }}
+        - name: KUBEVIZ_CLUSTER_NAME
+          value: {{ .Values.Agent.ClusterName }}
+        {{- end }}


### PR DESCRIPTION
By default, the label that is looked for in the agent when polling the kube api is "clusterName".  If your labels are different, this allows you to specify the node label to use for the cluster name.